### PR TITLE
HLT menu running global pixel reconstruction on GPU

### DIFF
--- a/customise_PixelGPU.py
+++ b/customise_PixelGPU.py
@@ -1,0 +1,228 @@
+import FWCore.ParameterSet.Config as cms
+
+# customisation for offloading the Pixel local reconstruction to GPUs
+
+# FIXME - existing modules are redefined *after* the sequences that contain them to avoid expanding them - FIXME
+
+def customise_PixelGPU(process):
+
+    # Services
+
+    process.CUDAService = cms.Service("CUDAService",
+        allocator = cms.untracked.PSet(
+            binGrowth = cms.untracked.uint32(8),
+            debug = cms.untracked.bool(False),
+            devicePreallocate = cms.untracked.vuint32(),
+            enabled = cms.untracked.bool(True),
+            hostPreallocate = cms.untracked.vuint32(),
+            maxBin = cms.untracked.uint32(9),
+            maxCachedBytes = cms.untracked.uint32(0),
+            maxCachedFraction = cms.untracked.double(0.8),
+            minBin = cms.untracked.uint32(1)
+        ),
+        enabled = cms.untracked.bool(True),
+        limits = cms.untracked.PSet(
+            cudaLimitDevRuntimePendingLaunchCount = cms.untracked.int32(-1),
+            cudaLimitDevRuntimeSyncDepth = cms.untracked.int32(-1),
+            cudaLimitMallocHeapSize = cms.untracked.int32(-1),
+            cudaLimitPrintfFifoSize = cms.untracked.int32(-1),
+            cudaLimitStackSize = cms.untracked.int32(-1)
+        )
+    )
+
+
+    # Event Setup
+     
+    process.siPixelGainCalibrationForHLTGPU = cms.ESProducer("SiPixelGainCalibrationForHLTGPUESProducer",
+        appendToDataLabel = cms.string('')
+    )
+
+    process.siPixelFedCablingMapGPUWrapper = cms.ESProducer("SiPixelFedCablingMapGPUWrapperESProducer",
+        CablingMapLabel = cms.string(''),
+        ComponentName = cms.string(''),
+        UseQualityInfo = cms.bool(False),
+        appendToDataLabel = cms.string('')
+    )
+
+    process.PixelCPEFastESProducer = cms.ESProducer("PixelCPEFastESProducer",
+        Alpha2Order = cms.bool(True),
+        ClusterProbComputationFlag = cms.int32(0),
+        ComponentName = cms.string('PixelCPEFast'),
+        EdgeClusterErrorX = cms.double(50.0),
+        EdgeClusterErrorY = cms.double(85.0),
+        LoadTemplatesFromDB = cms.bool(True),
+        MagneticFieldRecord = cms.ESInputTag(""),
+        TruncatePixelCharge = cms.bool(True),
+        UseErrorsFromTemplates = cms.bool(True),
+        useLAAlignmentOffsets = cms.bool(False),
+        useLAWidthFromDB = cms.bool(True)
+    )
+
+
+    # introduce new modules and aliases
+
+    process.hltOnlineBeamSpotCUDA = cms.EDProducer("BeamSpotToCUDA",
+        src = cms.InputTag("hltOnlineBeamSpot")
+    )
+
+    process.siPixelClustersCUDAPreSplitting = cms.EDProducer("SiPixelRawToClusterCUDA",
+        CablingMapLabel = cms.string(''),
+        IncludeErrors = cms.bool(True),
+        InputLabel = cms.InputTag("rawDataCollector"),
+        Regions = cms.PSet(
+        ),
+        UsePilotBlade = cms.bool(False),
+        UseQualityInfo = cms.bool(False)
+    )
+
+    process.siPixelRecHitsCUDAPreSplitting = cms.EDProducer("SiPixelRecHitCUDA",
+        CPE = cms.string('PixelCPEFast'),
+        beamSpot = cms.InputTag("hltOnlineBeamSpotCUDA"),
+        src = cms.InputTag("siPixelClustersCUDAPreSplitting")
+    )
+
+    process.siPixelDigisSoA = cms.EDProducer("SiPixelDigisSoAFromCUDA",
+        src = cms.InputTag("siPixelClustersCUDAPreSplitting")
+    )
+
+    process.siPixelDigisClustersPreSplitting = cms.EDProducer("SiPixelDigisClustersFromSoA",
+        src = cms.InputTag("siPixelDigisSoA")
+    )
+
+    process.siPixelDigiErrorsSoA = cms.EDProducer("SiPixelDigiErrorsSoAFromCUDA",
+        src = cms.InputTag("siPixelClustersCUDAPreSplitting")
+    )
+
+    process.siPixelDigiErrors = cms.EDProducer("SiPixelDigiErrorsFromSoA",
+        CablingMapLabel = cms.string(''),
+        ErrorList = cms.vint32(29),
+        UsePhase1 = cms.bool(True),
+        UserErrorList = cms.vint32(40),
+        digiErrorSoASrc = cms.InputTag("siPixelDigiErrorsSoA")
+    )
+
+    process.pixelTracksHitQuadruplets = cms.EDProducer("CAHitNtupletHeterogeneousEDProducer",
+        heterogeneousEnabled_ = cms.untracked.PSet(
+            GPUCuda = cms.untracked.bool(True),
+            force = cms.untracked.string('')
+        ),
+        gpuEnableTransfer = cms.bool(True),
+        gpuEnableConversion = cms.bool(True),
+        CAHardPtCut = cms.double(0),
+        CAPhiCut = cms.double(10),
+        CAThetaCut = cms.double(0.00125),
+        CAThetaCutBarrel = cms.double(0.00200000009499),
+        CAThetaCutForward = cms.double(0.00300000002608),
+        dcaCutInnerTriplet = cms.double(0.15000000596),
+        dcaCutOuterTriplet = cms.double(0.25),
+        doClusterCut = cms.bool(True),
+        doPhiCut = cms.bool(True),
+        doZCut = cms.bool(True),
+        earlyFishbone = cms.bool(False),
+        fillStatistics = cms.bool(False),
+        fit5as4 = cms.bool(True),
+        hardCurvCut = cms.double(0.0328407224959),
+        idealConditions = cms.bool(True),
+        lateFishbone = cms.bool(True),
+        minHitsPerNtuplet = cms.uint32(4),
+        pixelRecHitLegacySrc = cms.InputTag("hltSiPixelRecHits"),
+        pixelRecHitSrc = cms.InputTag("siPixelRecHitsCUDAPreSplitting"),
+        ptmin = cms.double(0.899999976158),
+        trackingRegions = cms.InputTag("hltPixelTracksTrackingRegions"),
+        useRiemannFit = cms.bool(False)
+    )
+
+
+    # redefine existing sequences
+
+    process.HLTDoLocalPixelSequence = cms.Sequence(
+          process.hltOnlineBeamSpot
+        + process.hltOnlineBeamSpotCUDA                     # beamspot on gpu
+        + process.siPixelClustersCUDAPreSplitting           # digis and clusters on gpu
+        + process.siPixelRecHitsCUDAPreSplitting            # rechits on gpu
+        + process.siPixelDigisSoA                           # copy to host
+        + process.siPixelDigisClustersPreSplitting          # convert to legacy
+        + process.siPixelDigiErrorsSoA                      # copy to host
+        + process.siPixelDigiErrors                         # convert to legacy
+        # process.hltSiPixelDigis                           # alias
+        # process.hltSiPixelClusters                        # alias
+        + process.hltSiPixelClustersCache                   # not used here, kept for compatibility with legacy sequences
+        + process.hltSiPixelRecHits )                       # convert to legacy
+
+    process.HLTRecoPixelTracksSequence = cms.Sequence(
+          process.hltPixelTracksFitter                      # not used here, kept for compatibility with legacy sequences
+        + process.hltPixelTracksFilter                      # not used here, kept for compatibility with legacy sequences
+        + process.hltPixelTracksTrackingRegions
+        + process.pixelTracksHitQuadruplets                 # pixel ntuplets on gpu, with transfer and conversion to legacy
+        + process.hltPixelTracks                            # pixel tracks on gpu, with transfer and conversion to legacy
+        + process.hltPixelVertices )                        # pixel vertices on gpu, with transfer and conversion to legacy
+
+
+    # replace the existing modules with new modules or aliases
+
+    process.hltSiPixelRecHits = cms.EDProducer("SiPixelRecHitFromSOA",
+        pixelRecHitSrc = cms.InputTag("siPixelRecHitsCUDAPreSplitting"),
+        src = cms.InputTag("siPixelDigisClustersPreSplitting")
+    )
+
+    process.hltSiPixelDigis = cms.EDAlias(
+        siPixelDigisClustersPreSplitting = cms.VPSet(
+            cms.PSet(
+                type = cms.string('PixelDigiedmDetSetVector')
+            )
+        ),
+        siPixelDigiErrors = cms.VPSet(
+            cms.PSet(
+                type = cms.string('DetIdedmEDCollection')
+            ), 
+            cms.PSet(
+                type = cms.string('SiPixelRawDataErroredmDetSetVector')
+            ), 
+            cms.PSet(
+                type = cms.string('PixelFEDChanneledmNewDetSetVector')
+            )
+        )
+    )
+
+    process.hltSiPixelClusters = cms.EDAlias(
+        siPixelDigisClustersPreSplitting = cms.VPSet(
+            cms.PSet(
+                type = cms.string('SiPixelClusteredmNewDetSetVector')
+            )
+        )
+    )
+
+    process.hltPixelTracks = cms.EDProducer("PixelTrackProducerFromCUDA",
+        heterogeneousEnabled_ = cms.untracked.PSet(
+            GPUCuda = cms.untracked.bool(True),
+            force = cms.untracked.string('')
+        ),
+        gpuEnableConversion = cms.bool(True),
+        beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+        src = cms.InputTag("pixelTracksHitQuadruplets")
+    )
+
+    process.hltPixelVertices = cms.EDProducer("PixelVertexHeterogeneousProducer",
+        heterogeneousEnabled_ = cms.untracked.PSet(
+            GPUCuda = cms.untracked.bool(True),
+            force = cms.untracked.string('')
+        ),
+        gpuEnableTransfer = cms.bool(True),
+        gpuEnableConversion = cms.bool(True),
+        PtMin = cms.double(0.5),
+        TrackCollection = cms.InputTag("hltPixelTracks"),
+        beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+        chi2max = cms.double(9),
+        eps = cms.double(0.07),
+        errmax = cms.double(0.01),
+        minT = cms.int32(2),
+        src = cms.InputTag("pixelTracksHitQuadruplets"),
+        useDBSCAN = cms.bool(False),
+        useDensity = cms.bool(True),
+        useIterative = cms.bool(False)
+    )
+
+
+    # done
+
+    return process

--- a/customise_gpu.py
+++ b/customise_gpu.py
@@ -54,12 +54,16 @@ def customise_gpu_pixel(process):
         ComponentName = cms.string('PixelCPEFast'),
         EdgeClusterErrorX = cms.double(50.0),
         EdgeClusterErrorY = cms.double(85.0),
+        DoLorentz = cms.bool(True),
         LoadTemplatesFromDB = cms.bool(True),
         MagneticFieldRecord = cms.ESInputTag(""),
         TruncatePixelCharge = cms.bool(True),
         UseErrorsFromTemplates = cms.bool(True),
         useLAAlignmentOffsets = cms.bool(False),
-        useLAWidthFromDB = cms.bool(True)
+        useLAWidthFromDB = cms.bool(True),
+        lAOffset = cms.double(0.0),
+        lAWidthBPix = cms.double(0.0),
+        lAWidthFPix = cms.double(0.0)
     )
 
 
@@ -173,7 +177,7 @@ def customise_gpu_pixel(process):
     process.hltPixelVerticesCUDA = cms.EDProducer("PixelVertexProducerCUDA",
         onGPU = cms.bool(True),
         PtMin = cms.double(0.5),
-        pixelTrackSrc = cms.InputTag("hltPixelTracks"),
+        pixelTrackSrc = cms.InputTag("hltPixelTracksHitQuadruplets"),
         chi2max = cms.double(9),
         eps = cms.double(0.07),
         errmax = cms.double(0.01),
@@ -188,7 +192,7 @@ def customise_gpu_pixel(process):
     )
 
     process.hltPixelVertices = cms.EDProducer("PixelVertexProducerFromSoA",
-        src = cms.InputTag("pixelTrackSoA"),
+        src = cms.InputTag("hltPixelVerticesSoA"),
         beamSpot = cms.InputTag("hltOnlineBeamSpot"),
         TrackCollection = cms.InputTag("hltPixelTracks"),
     )
@@ -219,6 +223,7 @@ def customise_gpu_pixel(process):
         + process.hltPixelTracksFilter                      # not used here, kept for compatibility with legacy sequences
         + process.hltPixelTracksTrackingRegions             #
         + process.hltPixelTracksHitQuadruplets              # pixel ntuplets on gpu, with transfer and conversion to legacy
+        + process.hltPixelTracksSoA
         + process.hltPixelTracks)                           # pixel tracks on gpu, with transfer and conversion to legacy
 
     process.HLTRecopixelvertexingSequence = cms.Sequence(

--- a/customise_gpu.py
+++ b/customise_gpu.py
@@ -27,6 +27,8 @@ def customise_gpu_common(process):
         )
     )
 
+    process.load('HeterogeneousCore.CUDAServices.NVProfilerService_cfi')
+
     # done
     return process
 
@@ -237,8 +239,106 @@ def customise_gpu_pixel(process):
     return process
 
 
+# customisation for offloading the ECAL local reconstruction to GPUs
+# TODO find automatically the list of Sequences to be updated
+def customise_gpu_ecal(process):
+
+    # FIXME replace the Sequences with empty ones to avoid exanding them during the (re)definition of Modules and EDAliases
+
+    process.HLTDoFullUnpackingEgammaEcalMFSequence = cms.Sequence()
+    process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerSequence = cms.Sequence()
+    process.HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence()
+
+
+    # Event Setup
+
+    process.load("RecoLocalCalo.EcalRecProducers.ecalGainRatiosGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalPedestalsGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalPulseCovariancesGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalPulseShapesGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalSamplesCorrelationGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalTimeBiasCorrectionsGPUESProducer_cfi")
+    process.load("RecoLocalCalo.EcalRecProducers.ecalTimeCalibConstantsGPUESProducer_cfi")
+
+
+    # Modules and EDAliases
+
+    process.hltEcalUncalibRecHitSoA = cms.EDProducer("EcalUncalibRecHitProducerGPU",
+        digisLabelEB = cms.InputTag("hltEcalDigis","ebDigis"),
+        recHitsLabelEB = cms.string('EcalUncalibRecHitsEB'),
+        digisLabelEE = cms.InputTag("hltEcalDigis","eeDigis"),
+        recHitsLabelEE = cms.string('EcalUncalibRecHitsEE'),
+        EBamplitudeFitParameters = cms.vdouble(1.138, 1.652),
+        EBtimeConstantTerm = cms.double(0.6),
+        EBtimeFitLimits_Lower = cms.double(0.2),
+        EBtimeFitLimits_Upper = cms.double(1.4),
+        EBtimeFitParameters = cms.vdouble(-2.015452, 3.130702, -12.3473, 41.88921, -82.83944, 91.01147, -50.35761, 11.05621),
+        EBtimeNconst = cms.double(28.5),
+        EEamplitudeFitParameters = cms.vdouble(1.89, 1.4),
+        EEtimeConstantTerm = cms.double(1.0),
+        EEtimeFitLimits_Lower = cms.double(0.2),
+        EEtimeFitLimits_Upper = cms.double(1.4),
+        EEtimeFitParameters = cms.vdouble(-2.390548, 3.553628, -17.62341, 67.67538, -133.213, 140.7432, -75.41106, 16.20277),
+        EEtimeNconst = cms.double(31.8),
+        amplitudeThresholdEB = cms.double(10.0),
+        amplitudeThresholdEE = cms.double(10.0),
+        outOfTimeThresholdGain12mEB = cms.double(5.0),
+        outOfTimeThresholdGain12mEE = cms.double(1000.0),
+        outOfTimeThresholdGain12pEB = cms.double(5.0),
+        outOfTimeThresholdGain12pEE = cms.double(1000.0),
+        outOfTimeThresholdGain61mEB = cms.double(5.0),
+        outOfTimeThresholdGain61mEE = cms.double(1000.0),
+        outOfTimeThresholdGain61pEB = cms.double(5.0),
+        outOfTimeThresholdGain61pEE = cms.double(1000.0),
+        kernelMinimizeThreads = cms.vuint32(32, 1, 1),
+        maxNumberHits = cms.uint32(20000),
+        shouldRunTimingComputation = cms.bool(False),
+        shouldTransferToHost = cms.bool(True)
+    )
+
+    process.hltEcalUncalibRecHit = cms.EDProducer('EcalUncalibRecHitConvertGPU2CPUFormat',
+        recHitsLabelGPUEB = cms.InputTag('hltEcalUncalibRecHitSoA', 'EcalUncalibRecHitsEB'),
+        recHitsLabelGPUEE = cms.InputTag('hltEcalUncalibRecHitSoA', 'EcalUncalibRecHitsEE'),
+        recHitsLabelCPUEB = cms.string('EcalUncalibRecHitsEB'),
+        recHitsLabelCPUEE = cms.string('EcalUncalibRecHitsEE')
+    )
+
+
+    # Sequences
+
+    process.HLTDoFullUnpackingEgammaEcalMFSequence = cms.Sequence(
+        process.hltEcalDigis
+      + process.hltEcalPreshowerDigis
+      + process.hltEcalUncalibRecHitSoA
+      + process.hltEcalUncalibRecHit
+      + process.hltEcalDetIdToBeRecovered
+      + process.hltEcalRecHit
+      + process.hltEcalPreshowerRecHit)
+
+    process.HLTDoFullUnpackingEgammaEcalWithoutPreshowerSequence = cms.Sequence(
+        process.hltEcalDigis
+      + process.hltEcalUncalibRecHitSoA
+      + process.hltEcalUncalibRecHit
+      + process.hltEcalDetIdToBeRecovered
+      + process.hltEcalRecHit)
+
+    process.HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(
+        process.hltEcalDigis
+      + process.hltEcalPreshowerDigis
+      + process.hltEcalUncalibRecHitSoA
+      + process.hltEcalUncalibRecHit
+      + process.hltEcalDetIdToBeRecovered
+      + process.hltEcalRecHit
+      + process.hltEcalPreshowerRecHit)
+
+
+    # done
+    return process
+
+
 # customisation for offloading to GPUs
 def customise_gpu(process):
     process = customise_gpu_common(process)
     process = customise_gpu_pixel(process)
+    process = customise_gpu_ecal(process)
     return process

--- a/workflows/TTbar_13TeV_TuneCUETP8M1_cfi_GEN_SIM.py
+++ b/workflows/TTbar_13TeV_TuneCUETP8M1_cfi_GEN_SIM.py
@@ -1,0 +1,138 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: TTbar_13TeV_TuneCUETP8M1_cfi --conditions auto:phase1_2021_realistic -n 10 --era Run3 --eventcontent FEVTDEBUG --relval 9000,50 -s GEN,SIM --datatier GEN-SIM --beamspot Realistic25ns13TeVEarly2017Collision --geometry DB:Extended --fileout file:step1.root --no_exec --nThreads 8
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+process = cms.Process('SIM',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+#process.load('HeterogeneousCore.CUDAServices.CUDAService_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.GeometrySimDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('TTbar_13TeV_TuneCUETP8M1_cfi nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('step1.root'),
+    outputCommands = process.FEVTDEBUGEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.XMLFromDBSource.label = cms.string("Extended")
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    PythiaParameters = cms.PSet(
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings', 
+            'pythia8CUEP8M1Settings', 
+            'processParameters'
+        ),
+        processParameters = cms.vstring(
+            'Top:gg2ttbar = on ', 
+            'Top:qqbar2ttbar = on ', 
+            '6:m0 = 175 '
+        ),
+        pythia8CUEP8M1Settings = cms.vstring(
+            'Tune:pp 14', 
+            'Tune:ee 7', 
+            'MultipartonInteractions:pT0Ref=2.4024', 
+            'MultipartonInteractions:ecmPow=0.25208', 
+            'MultipartonInteractions:expPow=1.6'
+        ),
+        pythia8CommonSettings = cms.vstring(
+            'Tune:preferLHAPDF = 2', 
+            'Main:timesAllowErrors = 10000', 
+            'Check:epTolErr = 0.01', 
+            'Beams:setProductionScalesFromLHEF = off', 
+            'SLHA:keepSM = on', 
+            'SLHA:minMassSM = 1000.', 
+            'ParticleDecays:limitTau0 = on', 
+            'ParticleDecays:tau0Max = 10', 
+            'ParticleDecays:allowPhotonRadiation = on'
+        )
+    ),
+    comEnergy = cms.double(13000.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(0)
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.endjob_step,process.FEVTDEBUGoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads=cms.untracked.uint32(4)
+process.options.numberOfStreams=cms.untracked.uint32(4)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.ProductionFilterSequence)
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/workflows/step2.py
+++ b/workflows/step2.py
@@ -1,0 +1,105 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step2 --no_exec --conditions auto:phase1_2021_realistic --pileup_input das:/RelValMinBias_13/CMSSW_10_6_0_pre3-105X_postLS2_realistic_v6-v1/GEN-SIM -n 10 --era Run3 --eventcontent FEVTDEBUGHLT -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2018 --datatier GEN-SIM-DIGI-RAW --pileup Run3_Flat55To75_PoissonOOTPU --geometry DB:Extended --filein file:step1.root --fileout file:step2.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('HLT',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mix_Run3_Flat55To75_PoissonOOTPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('HLTrigger.Configuration.HLT_GRun_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring('file:step1.root'),
+    inputCommands = cms.untracked.vstring(
+        'keep *'   ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step2 nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:step2.root'),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.mix.input.fileNames = cms.untracked.vstring(['/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/38806EE1-709B-404D-8744-485FFFEBCE77.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/6CF4F679-7EA3-0F42-841E-66DD4DD05943.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/037E40A0-0D58-BB43-B32D-34BA65435B27.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/644621DF-62ED-E34F-A25A-F9871DC2612C.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/41F88CCA-3E51-5441-B284-DF542FCEB6E5.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/3EC307BB-54BA-2443-90EA-FD926B91FA9A.root'])
+
+process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+
+# Path and EndPath definitions
+process.digitisation_step = cms.Path(process.pdigi_valid)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.digi2raw_step = cms.Path(process.DigiToRaw)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.digitisation_step,process.L1simulation_step,process.digi2raw_step)
+process.schedule.extend(process.HLTSchedule)
+process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# customisation of the process.
+
+process.options.numberOfThreads=cms.untracked.uint32(4)
+process.options.numberOfStreams=cms.untracked.uint32(4)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
+
+# Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforMC
+from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC 
+
+#call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
+process = customizeHLTforMC(process)
+
+# End of customisation functions
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/workflows/step3_patatrack.py
+++ b/workflows/step3_patatrack.py
@@ -1,0 +1,162 @@
+# Auto generated configuration file
+# using:
+# Revision: 1.19
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v
+# with command line options: step3 --conditions auto:phase1_2021_realistic --pileup_input das:/RelValMinBias_13/CMSSW_10_6_0_pre3-105X_postLS2_realistic_v6-v1/GEN-SIM -n 10 --era Run3 --eventcontent RECOSIM,DQM -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM --datatier GEN-SIM-RECO,DQMIO --geometry DB:Extended --pileup Run3_Flat55To75_PoissonOOTPU --filein file:step2_1.root --fileout file:step3.root --procModifiers gpu --runUnscheduled
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.ProcessModifiers.gpu_cff import gpu
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+import sys
+process = cms.Process('Patatrack',Run3,gpu)
+from file_list import *
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('HeterogeneousCore.CUDAServices.CUDAService_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mix_Run3_Flat55To75_PoissonOOTPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
+process.load('DQMOffline.Configuration.DQMOfflineMC_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+options = VarParsing ('analysis')
+options.register ('skipFiles',0,VarParsing.multiplicity.singleton,VarParsing.varType.int,"Skip Files")
+options.register ('numFiles',100,VarParsing.multiplicity.singleton,VarParsing.varType.int,"Num Files")
+# options.register ('maxEvents',5000,VarParsing.multiplicity.singleton,VarParsing.varType.int,"Num Events")
+options.register ('fileName',"step3",VarParsing.multiplicity.singleton,VarParsing.varType.string,"File Name")
+options.parseArguments()
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+if options.skipFiles>len(file_list):
+    print("Skipping all files in the list.")
+    print("Returning.")
+    print("Bye.")
+    sys.exit(1)
+
+start = max(0,options.skipFiles)
+finish = min(options.numFiles+start,len(file_list))
+theList = file_list[start:finish]
+
+print("Processing files from %d to %d (tot=%d)"%(start,finish,len(theList)))
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(theList),
+    inputCommands = cms.untracked.vstring(
+        'keep *'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step3 nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+fname = options.fileName + "_" + str(start) + "_" + str(finish)
+
+output = process.FEVTDEBUGHLTEventContent.outputCommands
+#output.append("keep *_*tp*_*_*Pata*")
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW-RECO-HLTDEBUG'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:' + fname + 'hlt_patatrack.root'),
+    outputCommands = output,
+    splitLevel = cms.untracked.int32(0)
+)
+
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('DQMIO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:' + fname + 'hlt_patatrack_inDQM.root'),
+    outputCommands = process.DQMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Other statements
+process.mix.input.fileNames = cms.untracked.vstring(['file:/lustre/cms/store/user/adiflori/MINBIAS106X/037E40A0-0D58-BB43-B32D-34BA65435B27.root',
+'file:/lustre/cms/store/user/adiflori/MINBIAS106X/38806EE1-709B-404D-8744-485FFFEBCE77.root',
+'file:/lustre/cms/store/user/adiflori/MINBIAS106X/3EC307BB-54BA-2443-90EA-FD926B91FA9A.root',
+'file:/lustre/cms/store/user/adiflori/MINBIAS106X/41F88CCA-3E51-5441-B284-DF542FCEB6E5.root',
+'file:/lustre/cms/store/user/adiflori/MINBIAS106X/644621DF-62ED-E34F-A25A-F9871DC2612C.root',
+'file:/lustre/cms/store/user/adiflori/MINBIAS106X/6CF4F679-7EA3-0F42-841E-66DD4DD05943.root'])
+
+#process.mix.input.fileNames = cms.untracked.vstring(['/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/38806EE1-709B-404D-8744-485FFFEBCE77.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/6CF4F679-7EA3-0F42-841E-66DD4DD05943.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/037E40A0-0D58-BB43-B32D-34BA65435B27.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/644621DF-62ED-E34F-A25A-F9871DC2612C.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/41F88CCA-3E51-5441-B284-DF542FCEB6E5.root', '/store/relval/CMSSW_10_6_0_pre3/RelValMinBias_13/GEN-SIM/105X_postLS2_realistic_v6-v1/10000/3EC307BB-54BA-2443-90EA-FD926B91FA9A.root'])
+process.mix.playback = True
+process.mix.digitizers = cms.PSet()
+for a in process.aliases: delattr(process, a)
+process.RandomNumberGeneratorService.restoreStateLabel=cms.untracked.string("randomEngineStateProducer")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi_pixelOnly)
+process.reconstruction_step = cms.Path(process.reconstruction_pixelTrackingOnly)
+process.prevalidation_step = cms.Path(process.globalPrevalidationPixelTrackingOnly)
+process.validation_step = cms.EndPath(process.globalValidationPixelTrackingOnly)
+process.dqmoffline_step = cms.EndPath(process.DQMOfflinePixelTracking)
+process.dqmofflineOnPAT_step = cms.EndPath(process.PostDQMOffline)
+#process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.reconstruction_step,process.prevalidation_step,process.validation_step,process.dqmoffline_step,process.dqmofflineOnPAT_step,process.FEVTDEBUGHLToutput_step,process.DQMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# customisation of the process.
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+# Automatic addition of the customisation function from SimGeneral.MixingModule.fullMixCustomize_cff
+from SimGeneral.MixingModule.fullMixCustomize_cff import setCrossingFrameOn
+
+#call to customisation function setCrossingFrameOn imported from SimGeneral.MixingModule.fullMixCustomize_cff
+process = setCrossingFrameOn(process)
+
+# End of customisation functions
+#do not add changes to your config after this point (unless you know what you are doing)
+#from FWCore.ParameterSet.Utilities import convertToUnscheduled
+#process=convertToUnscheduled(process)
+
+process.options.numberOfThreads=cms.untracked.uint32(2)
+process.options.numberOfStreams=cms.untracked.uint32(2)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(2)
+
+#process.Timing = cms.Service("Timing",
+#  summaryOnly = cms.untracked.bool(False),
+#  useJobReport = cms.untracked.bool(True)
+#)
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
The global pixel digis, clusters and rechits are converted to the legacy formats and reused by the regional reconstruction.

The speed up with respect to the original HLT menu is about 5%.
The conversion to the legacy formats accounts for 3% of the time, so without it (assuming the legacy modules will be updated to read the SoA data formats directly) the speed up should be of 8% .

Original pie chart, running on CPU:
![image](https://user-images.githubusercontent.com/4069793/60752828-af041000-9fca-11e9-95e5-6950bda9c879.png)

Pie chart running on GPU:
![image](https://user-images.githubusercontent.com/4069793/60752834-c3e0a380-9fca-11e9-9b8f-536a0efa9934.png)

Zoom of the `Pixels on GPU` slice:
![image](https://user-images.githubusercontent.com/4069793/60752840-d955cd80-9fca-11e9-82f3-88b1911cca93.png)

